### PR TITLE
Move Font Awesome to local dependency away from Bootstrap CDN

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ gulp.task("less", function() {
   return gulp.src("src/less/main.less")
     .pipe(less({outputStyle : "compressed"}))
     .pipe(autoprefixer({browsers : ["last 20 versions"]}))
+    .pipe(gulp.dest("static/css"))
     .pipe(csscomb())
     .pipe(cleancss())
     .pipe(hash())
@@ -39,10 +40,16 @@ gulp.task("headers", ['less'], function() {
     .pipe(gulp.dest('static'))
 })
 
+// Copy our fontawesome fonts into the static dir
+gulp.task("fonts", function() {
+  gulp.src('node_modules/font-awesome/fonts/fontawesome-webfont.*')
+    .pipe(gulp.dest('static/css/fonts'))
+})
+
 // Watch asset folder for changes
-gulp.task("watch", ["less"], function () {
+gulp.task("watch", ['less', 'fonts'], function () {
   gulp.watch(["src/less/*.less", "src/less/**/*.less"], ["less"])
 })
 
 // Build task
-gulp.task('default', ['less', 'headers'])
+gulp.task('default', ['less', 'fonts', 'headers'])

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,6 @@
     {{ .Hugo.Generator }}
 {{ partial "head_meta.html" . }}
     <link rel="stylesheet" href="/css/{{ index .Site.Data.css.hash "main.css" }}" />
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
     <title>{{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}{{ if eq $url "" }}{{ .Site.Title }}{{ else }}{{ .Site.Title }} &middot; {{ .Title }}{{ if .Params.heading }}{{ .Params.heading }}{{ else }}{{ end }}{{ end }}</title>
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "del": "^2.2.2",
+    "font-awesome": "^4.7.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-clean-css": "^3.0.4",

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -47,5 +47,11 @@
 @import '../../node_modules/spectre.css/src/animations.less';
 @import '../../node_modules/spectre.css/src/utilities.less';
 
+// Font Awesome
+@import '../../node_modules/font-awesome/less/font-awesome.less';
+// Set our font path
+// This must be done after the above so we override it
+@fa-font-path: '../css/fonts';
+
 // Default styles
 @import 'styles.less';


### PR DESCRIPTION
I'm hoping this will actually prove to be faster with HTTP/2 although it doesn't change the fact that the current FA CDN may already be cached.

Either way its another connection to an external source that doesn't need to be made.