### PR TITLE
[WIP] Add site search

### DIFF
--- a/content/issues/_index.md
+++ b/content/issues/_index.md
@@ -1,0 +1,6 @@
+---
+title: 'Issues'
+outputs:
+  - 'HTML'
+  - 'JSON'
+---

--- a/layouts/issues/list.json
+++ b/layouts/issues/list.json
@@ -1,5 +1,6 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range .Data.Pages -}}
-{{- $.Scratch.Add "index" (dict "objectID" ( printf "issue_%s" .Slug ) "issue" ( int .Slug ) "uri" .Permalink "title" .Title "blurb" ( .Params.description | plainify ) "tags" .Params.tags) -}}
+  {{- $.Scratch.Add "index" (dict "action" "addObject" "body" ( dict "objectID" ( printf "issue_%s" .Slug ) "issue" ( int .Slug ) "uri" .Permalink "title" .Title "blurb" ( .Params.description | plainify ) "tags" .Params.tags) ) -}}
 {{- end -}}
-{{- $.Scratch.Get "index" | jsonify -}}
+{{- $list := $.Scratch.Get "index" -}}
+{{- (dict "requests" $list ) | jsonify -}}

--- a/layouts/issues/list.json
+++ b/layouts/issues/list.json
@@ -1,0 +1,5 @@
+{{- $.Scratch.Add "index" slice -}}
+{{- range .Data.Pages -}}
+{{- $.Scratch.Add "index" (dict "objectID" ( printf "issue_%s" .Slug ) "issue" ( int .Slug ) "uri" .Permalink "title" .Title "blurb" ( .Params.description | plainify ) "tags" .Params.tags) -}}
+{{- end -}}
+{{- $.Scratch.Get "index" | jsonify -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[context.production.environment]
+  HUGO_VERSION = "0.18"
+
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.20"


### PR DESCRIPTION
This is very much a WIP however I'd like to add search to the website.

A quick look around suggests that Algolia might be a good option however it involves putting the data into their systems. This MR begins that work by creating a JSON file that can then (somehow, gulp maybe?) be sent to their API for ingestion into the index.

TODO:

- [ ]  Update Netlify to build website with newer version of Hugo (currently locked to 0.18 iirc)
     `hugo_0.20` currently throws an error building on Netlify